### PR TITLE
fix: [Bug]: While using with Breezy plugin, an error occurs with getFilamentAvatarUrl()

### DIFF
--- a/resources/views/user-avatar-option.blade.php
+++ b/resources/views/user-avatar-option.blade.php
@@ -1,6 +1,6 @@
 <div class="flex items-center gap-2">
     @if($user)
-        <x-filament-panels::avatar.user :user="$user" size="sm" />
+        <x-filament-panels::avatar.user :user="$user" size="xs" />
         <span class="text-sm font-medium">{{ filament()->getUserName($user) }}</span>
     @endif
 </div>


### PR DESCRIPTION
Closes #11

Patch generated by `poolside/laguna-xs-2.1:free` via OpenRouter.